### PR TITLE
fix(workflow): avoid UI hook false positives

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,44 @@
+name: Publish npm packages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9.15.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish versions missing from npm
+        run: pnpm publish:changed
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.kimi-plugin/marketplace.json
+++ b/.kimi-plugin/marketplace.json
@@ -4,7 +4,7 @@
     {
       "id": "wiolett-industries",
       "displayName": "Wiolett Industries Agent Plugins",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "description": "Workflow, memory, and GitLab merge request review tools distributed as one aggregate Kimi Code plugin.",
       "homepage": "https://github.com/wiolett-industries/marketplace",
       "source": "https://github.com/wiolett-industries/marketplace",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,21 @@ pnpm --filter @wiolett/workflow test
 pnpm --filter @wiolett/merge-request-review test
 ```
 
+## npm Publishing
+
+The `Publish npm packages` GitHub Actions workflow runs after pushes to `main`
+and can also be started manually. It checks the root package and every public
+package under `packages/`, skips versions that already exist in npm, and
+publishes only missing versions.
+
+Configure a GitHub Actions repository secret named `NPM_TOKEN` with permission
+to publish the `@wiolett` packages. The token is provided to npm through the
+runner environment and must never be committed to the repository.
+
+Before merging a package change, update its version according to the versioning
+rules above. A failed partial publish is safe to rerun because already published
+versions are skipped.
+
 ## Pull Requests
 
 Keep pull requests focused and describe:

--- a/kimi.plugin.json
+++ b/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wiolett-industries",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Wiolett Industries workflow, memory, and GitLab merge request review plugins for Kimi Code.",
   "keywords": [
     "workflow",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "plugins:install": "pnpm install",
     "plugin:agent-memory:install": "pnpm install --filter @wiolett/agent-memory",
+    "publish:changed": "node scripts/publish-changed-packages.mjs",
     "build": "pnpm --filter @wiolett/agent-memory build && pnpm --filter @wiolett/workflow build && pnpm --filter @wiolett/merge-request-review build",
     "test": "pnpm --filter @wiolett/agent-memory test && pnpm --filter @wiolett/workflow test && pnpm --filter @wiolett/merge-request-review test",
     "typecheck": "pnpm --filter @wiolett/agent-memory typecheck && pnpm --filter @wiolett/workflow typecheck && pnpm --filter @wiolett/merge-request-review typecheck"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiolett/marketplace",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "type": "module",
   "description": "Unified Codex and Claude Code plugin marketplace for Wiolett Industries MCP-backed workflow, memory, and review plugins.",
   "license": "MIT",

--- a/packages/workflow/agents/workflow_implementer.toml
+++ b/packages/workflow/agents/workflow_implementer.toml
@@ -33,7 +33,7 @@ Do not accept open-ended analysis, architecture discovery, large refactors, cros
 
 - Work only in your assigned worktree.
 - Follow existing repo patterns.
-- For UI work, require the assigned reuse receipt before coding: target, shared primitive path/export, analogous layout path, decision, and structural verification. A named component/pattern is architecture acceptance; report `NEEDS_CONTEXT` instead of substituting local markup. Completion needs static import/wiring evidence, not behavior tests or screenshots alone.
+- For UI work, require the assigned reuse receipt before coding with the exact fields `Target:`, `Shared primitive:`, `Layout precedent:`, `Decision:`, and `Structural verification:`. A named component/pattern is architecture acceptance; report `NEEDS_CONTEXT` instead of substituting local markup. Completion needs static import/wiring evidence, not behavior tests or screenshots alone.
 - Do not expand scope.
 - Do not disable or weaken lint/test rules to pass.
 - Keep changed files focused.

--- a/packages/workflow/agents/workflow_implementer_complex.toml
+++ b/packages/workflow/agents/workflow_implementer_complex.toml
@@ -33,7 +33,7 @@ You may take on analysis-before-coding for the assigned task. Do not take on cro
 
 - Work only in your assigned worktree.
 - Follow existing repo patterns; when a new pattern is unavoidable, keep it consistent with surrounding code and note it in Concerns.
-- For UI work, require the assigned reuse receipt before coding: target, shared primitive path/export, analogous layout path, decision, and structural verification. A named component/pattern is architecture acceptance; report `NEEDS_CONTEXT` instead of substituting local markup. Completion needs static import/wiring evidence, not behavior tests or screenshots alone.
+- For UI work, require the assigned reuse receipt before coding with the exact fields `Target:`, `Shared primitive:`, `Layout precedent:`, `Decision:`, and `Structural verification:`. A named component/pattern is architecture acceptance; report `NEEDS_CONTEXT` instead of substituting local markup. Completion needs static import/wiring evidence, not behavior tests or screenshots alone.
 - Stay within the assigned task boundary; do not expand scope.
 - Do not disable or weaken lint/test rules to pass.
 - Keep changed files focused.

--- a/packages/workflow/agents/workflow_implementer_standard.toml
+++ b/packages/workflow/agents/workflow_implementer_standard.toml
@@ -33,7 +33,7 @@ Do not accept open-ended architecture discovery, cross-repo investigations, or w
 
 - Work only in your assigned worktree.
 - Follow existing repo patterns.
-- For UI work, require the assigned reuse receipt before coding: target, shared primitive path/export, analogous layout path, decision, and structural verification. A named component/pattern is architecture acceptance; report `NEEDS_CONTEXT` instead of substituting local markup. Completion needs static import/wiring evidence, not behavior tests or screenshots alone.
+- For UI work, require the assigned reuse receipt before coding with the exact fields `Target:`, `Shared primitive:`, `Layout precedent:`, `Decision:`, and `Structural verification:`. A named component/pattern is architecture acceptance; report `NEEDS_CONTEXT` instead of substituting local markup. Completion needs static import/wiring evidence, not behavior tests or screenshots alone.
 - Stay within the assigned scope; do not expand it.
 - Do not disable or weaken lint/test rules to pass.
 - Keep changed files focused.

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiolett/workflow",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "type": "module",
   "description": "Workflow MCP runtime for custom-agent sync plus filesystem-backed plan, audit, handoff, and UI contract artifacts.",
   "license": "MIT",

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -4,7 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { formatWorkflowAgentSyncResult, registerWorkflowTools, syncWorkflowAgents } from './register.js';
 
-const VERSION = '1.1.8';
+const VERSION = '1.1.9';
 
 async function main(): Promise<void> {
   const [command] = process.argv.slice(2);

--- a/packages/workflow/test/plugin-hooks.test.mjs
+++ b/packages/workflow/test/plugin-hooks.test.mjs
@@ -82,6 +82,8 @@ test('workflow session hook emits recovery context for active plans', () => {
   assert.match(output.hookSpecificOutput.additionalContext, /Minimal means behavior-complete/);
   assert.match(output.hookSpecificOutput.additionalContext, /UI reuse gate/);
   assert.match(output.hookSpecificOutput.additionalContext, /reuse receipt/);
+  assert.match(output.hookSpecificOutput.additionalContext, /`Layout precedent:`/);
+  assert.doesNotMatch(output.hookSpecificOutput.additionalContext, /analogous layout path/i);
   assert.match(output.hookSpecificOutput.additionalContext, /architecture acceptance/);
   assert.match(output.hookSpecificOutput.additionalContext, /UI composition gate/);
   assert.match(output.hookSpecificOutput.additionalContext, /screenshots alone do not prove reuse/);
@@ -346,7 +348,9 @@ test('workflow subagent start reminds implementers to stay bounded', () => {
   assert.match(output.hookSpecificOutput.additionalContext, /no open-ended analysis/);
   assert.match(output.hookSpecificOutput.additionalContext, /read boundary/);
   assert.match(output.hookSpecificOutput.additionalContext, /implement assigned behavior completely/);
-  assert.match(output.hookSpecificOutput.additionalContext, /receipt naming target/);
+  assert.match(output.hookSpecificOutput.additionalContext, /receipt with the exact fields/);
+  assert.match(output.hookSpecificOutput.additionalContext, /`Layout precedent:`/);
+  assert.doesNotMatch(output.hookSpecificOutput.additionalContext, /analogous layout path/i);
   assert.match(output.hookSpecificOutput.additionalContext, /architecture acceptance/);
   assert.match(output.hookSpecificOutput.additionalContext, /no local substitute or wrapper/);
 });
@@ -398,6 +402,12 @@ test('Codex Stop allows reviewed and awaiting-user commitment states', () => {
 });
 
 test('Codex Stop requires a complete reuse receipt when final output reports UI files', () => {
+  const mentionOnly = runHook({
+    hook_event_name: 'Stop',
+    last_assistant_message: 'The signing method is implemented in src/Wallet.tsx; no file was changed.',
+  });
+  assert.equal(mentionOnly.continue, true);
+
   const missing = runHook({
     hook_event_name: 'Stop',
     last_assistant_message: 'Implemented src/Table.tsx and tests pass.',
@@ -458,7 +468,28 @@ test('Codex Stop enforces active-plan UI receipts and final structural evidence'
   writeFileSync(path.join(planDir, 'state.json'), JSON.stringify({ phase: 'executing' }), 'utf8');
   writeFileSync(path.join(planDir, 'ui-contract.md'), '# UI Contract\n\nProduction table change.\n', 'utf8');
 
-  const missing = runHook({ hook_event_name: 'Stop', cwd: workspace }, workspace);
+  const ordinaryQuestion = runHook({
+    hook_event_name: 'Stop',
+    cwd: workspace,
+    last_assistant_message: 'The signing method is implemented in src/Wallet.tsx; no file was changed.',
+  }, workspace);
+  assert.equal(ordinaryQuestion.continue, true);
+
+  const uiCompletionMessage = [
+    'Implemented src/Table.tsx.',
+    'UI Reuse Evidence:',
+    'Target: src/Table.tsx',
+    'Shared primitive: src/shared/Table.tsx#Table',
+    'Layout precedent: src/screens/Users.tsx',
+    'Decision: reuse',
+    'Structural verification: PASS AST import assertion',
+  ].join('\n');
+
+  const missing = runHook({
+    hook_event_name: 'Stop',
+    cwd: workspace,
+    last_assistant_message: uiCompletionMessage,
+  }, workspace);
   assert.equal(missing.decision, 'block');
   assert.match(missing.reason, /UI Reuse Receipt/);
 
@@ -471,10 +502,18 @@ test('Codex Stop enforces active-plan UI receipts and final structural evidence'
     'Decision: reuse',
     'Structural verification: AST import assertion',
   ].join('\n'), 'utf8');
-  assert.equal(runHook({ hook_event_name: 'Stop', cwd: workspace }, workspace).continue, true);
+  assert.equal(runHook({
+    hook_event_name: 'Stop',
+    cwd: workspace,
+    last_assistant_message: uiCompletionMessage,
+  }, workspace).continue, true);
 
   writeFileSync(path.join(planDir, 'state.json'), JSON.stringify({ phase: 'finalizing' }), 'utf8');
-  const notVerified = runHook({ hook_event_name: 'Stop', cwd: workspace }, workspace);
+  const notVerified = runHook({
+    hook_event_name: 'Stop',
+    cwd: workspace,
+    last_assistant_message: uiCompletionMessage,
+  }, workspace);
   assert.equal(notVerified.decision, 'block');
   assert.match(notVerified.reason, /Structural verification: PASS/);
 
@@ -483,7 +522,11 @@ test('Codex Stop enforces active-plan UI receipts and final structural evidence'
     readFileSync(path.join(planDir, 'ui-contract.md'), 'utf8').replace('Structural verification: AST', 'Structural verification: PASS AST'),
     'utf8',
   );
-  assert.equal(runHook({ hook_event_name: 'Stop', cwd: workspace }, workspace).continue, true);
+  assert.equal(runHook({
+    hook_event_name: 'Stop',
+    cwd: workspace,
+    last_assistant_message: uiCompletionMessage,
+  }, workspace).continue, true);
 });
 
 test('Kimi Stop uses native exit-code blocking without changing Codex output', () => {
@@ -848,11 +891,13 @@ test('workflow skills preserve mandatory routing and MCP boundaries', () => {
 
   assert.match(usingWorkflow, /run a local `intent-gate` for non-trivial work/i);
   assert.match(usingWorkflow, /A skill trigger never implies an artifact, subagent, plan, or verification step/);
+  assert.match(usingWorkflow, /exact receipt labels.*`Layout precedent:`/);
   assert.match(usingWorkflow, /Read-only, no-edits, without changes/);
   assert.match(intentGate, /brief local routing decision, not optional ceremony and not an automatic subagent step/);
   assert.match(workflowMcp, /normal path, not a preference/);
   assert.match(writingPlans, /Manual `\.workflow\/` writes are fallback only/);
   assert.match(executingPlans, /manual state\/artifact writes are fallback only/i);
+  assert.match(executingPlans, /exact labels.*`Layout precedent:`/);
   assert.match(executingPlans, /workflow_plan_complete/);
   assert.match(finalizingPlan, /Manual findings\/state\/artifact writes are fallback only/);
   assert.match(finalizingPlan, /workflow_plan_complete/);
@@ -894,8 +939,20 @@ test('workflow prompts route subagents by task shape and cap review loops', () =
   assert.match(uiContract, /unapproved duplicate components, tokens, or layouts are `Important`/);
   assert.match(implementer, /bounded patch worker, not an architecture analyst/);
   assert.match(implementer, /require the assigned reuse receipt before coding/);
+  assert.match(implementer, /exact fields.*`Layout precedent:`/);
+  assert.doesNotMatch(implementer, /analogous layout path/i);
   assert.match(implementer, /Structural verification: PASS/);
   assert.match(implementer, /report `NEEDS_CONTEXT`/);
+  for (const [dir, extension] of [
+    ['packages/workflow/agents', '.toml'],
+    ['plugins/workflow/agents', '.md'],
+  ]) {
+    for (const name of ['workflow_implementer', 'workflow_implementer_standard', 'workflow_implementer_complex']) {
+      const prompt = readAgentFile(dir, name, extension);
+      assert.match(prompt, /exact fields.*`Layout precedent:`/);
+      assert.doesNotMatch(prompt, /analogous layout path/i);
+    }
+  }
   assert.match(explorer, /not a repository inventory agent/);
   assert.match(explorer, /six file slices, 20 KB of output, and three searches/);
   assert.match(fixTriage, /Stop low-value loops/);

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Lean, risk-budgeted workflows for Claude Code with one primary path, selective subagents, single-pass verification, and explicit completion gates.",
   "author": {
     "name": "Wiolett Industries",

--- a/plugins/workflow/.codex-plugin/plugin.json
+++ b/plugins/workflow/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Lean, risk-budgeted workflows for Codex with one primary path, focused context, selective subagents, single-pass verification, and explicit completion gates.",
   "author": {
     "name": "Wiolett Industries",

--- a/plugins/workflow/agents/workflow_implementer.md
+++ b/plugins/workflow/agents/workflow_implementer.md
@@ -33,7 +33,7 @@ Do not accept open-ended analysis, architecture discovery, large refactors, cros
 
 - Work only in your assigned worktree.
 - Follow existing repo patterns.
-- For UI work, require the assigned reuse receipt before coding: target, shared primitive path/export, analogous layout path, decision, and structural verification. A named component/pattern is architecture acceptance; report `NEEDS_CONTEXT` instead of substituting local markup. Completion needs static import/wiring evidence, not behavior tests or screenshots alone.
+- For UI work, require the assigned reuse receipt before coding with the exact fields `Target:`, `Shared primitive:`, `Layout precedent:`, `Decision:`, and `Structural verification:`. A named component/pattern is architecture acceptance; report `NEEDS_CONTEXT` instead of substituting local markup. Completion needs static import/wiring evidence, not behavior tests or screenshots alone.
 - Do not expand scope.
 - Do not disable or weaken lint/test rules to pass.
 - Keep changed files focused.

--- a/plugins/workflow/agents/workflow_implementer_complex.md
+++ b/plugins/workflow/agents/workflow_implementer_complex.md
@@ -33,7 +33,7 @@ You may take on analysis-before-coding for the assigned task. Do not take on cro
 
 - Work only in your assigned worktree.
 - Follow existing repo patterns; when a new pattern is unavoidable, keep it consistent with surrounding code and note it in Concerns.
-- For UI work, require the assigned reuse receipt before coding: target, shared primitive path/export, analogous layout path, decision, and structural verification. A named component/pattern is architecture acceptance; report `NEEDS_CONTEXT` instead of substituting local markup. Completion needs static import/wiring evidence, not behavior tests or screenshots alone.
+- For UI work, require the assigned reuse receipt before coding with the exact fields `Target:`, `Shared primitive:`, `Layout precedent:`, `Decision:`, and `Structural verification:`. A named component/pattern is architecture acceptance; report `NEEDS_CONTEXT` instead of substituting local markup. Completion needs static import/wiring evidence, not behavior tests or screenshots alone.
 - Stay within the assigned task boundary; do not expand scope.
 - Do not disable or weaken lint/test rules to pass.
 - Keep changed files focused.

--- a/plugins/workflow/agents/workflow_implementer_standard.md
+++ b/plugins/workflow/agents/workflow_implementer_standard.md
@@ -33,7 +33,7 @@ Do not accept open-ended architecture discovery, cross-repo investigations, or w
 
 - Work only in your assigned worktree.
 - Follow existing repo patterns.
-- For UI work, require the assigned reuse receipt before coding: target, shared primitive path/export, analogous layout path, decision, and structural verification. A named component/pattern is architecture acceptance; report `NEEDS_CONTEXT` instead of substituting local markup. Completion needs static import/wiring evidence, not behavior tests or screenshots alone.
+- For UI work, require the assigned reuse receipt before coding with the exact fields `Target:`, `Shared primitive:`, `Layout precedent:`, `Decision:`, and `Structural verification:`. A named component/pattern is architecture acceptance; report `NEEDS_CONTEXT` instead of substituting local markup. Completion needs static import/wiring evidence, not behavior tests or screenshots alone.
 - Stay within the assigned scope; do not expand it.
 - Do not disable or weaken lint/test rules to pass.
 - Keep changed files focused.

--- a/plugins/workflow/hooks/workflow-hook.cjs
+++ b/plugins/workflow/hooks/workflow-hook.cjs
@@ -350,7 +350,7 @@ function sessionContext(input) {
     "Run `intent-gate` locally for non-trivial work and keep it silent when intent is clear.",
     "Context budget is a hard gate: a new plan, resume, compaction, or hand-off never authorizes project inventory; start from the named surface and widen only for one named dependency.",
     "Minimum-solution gate: every plan item must trace to requested behavior, an observed failure, or a concrete normal-path risk. Minimal means behavior-complete: never omit accepted behavior, normal flow, integrity/security, or compatibility. Cut hypothetical edge cases, future-proofing, repeated-crash scenarios, and unrelated refactors.",
-    "UI reuse gate: before JSX/CSS, record a reuse receipt with target, shared primitive path/export, analogous layout path, reuse/adapt/none, and structural verification. A named shared component is architecture acceptance, not visual guidance.",
+    "UI reuse gate: before JSX/CSS, record a reuse receipt with the exact fields `Target:`, `Shared primitive:`, `Layout precedent:`, `Decision:`, and `Structural verification:`. A named shared component is architecture acceptance, not visual guidance.",
     "UI composition gate: shared-components-only forbids local substitutes, wrappers, tokens, and parallel layouts. Reuse/adapt the named primitive and analogous composition or ask; behavior tests and screenshots alone do not prove reuse.",
     "Task-wide ceilings: fast (0 agents), standard (at most 1 total), assurance (declared total, default 3; at most 2 reviewers per round), or an explicit audit budget.",
     "Authorization is permission, not activation. Parent Max/Ultra and multiple skills do not expand the budget.",
@@ -412,8 +412,20 @@ function validateStopGates(input) {
   ok();
 }
 
+function containsUiFile(source) {
+  return /(?:^|[\s`(])[^\s`()]+\.(?:tsx|jsx|vue|svelte|css|scss|sass|less)(?=\W|$)/imu.test(source);
+}
+
 function hasUiChangedFile(message) {
-  return /(?:^|[\s`(])[^\s`()]+\.(?:tsx|jsx|vue|svelte|css|scss|sass|less)(?=[:`,)\s]|$)/imu.test(message);
+  const changedFilesIndex = message.search(/^Changed files:/im);
+  if (changedFilesIndex >= 0) {
+    const remainder = message.slice(changedFilesIndex).replace(/^Changed files:[^\S\r\n]*/i, "");
+    const nextSection = remainder.search(/^(?:Verification|Concerns|UI Reuse Evidence):/im);
+    const changedFiles = nextSection >= 0 ? remainder.slice(0, nextSection) : remainder;
+    if (containsUiFile(changedFiles)) return true;
+  }
+
+  return /^(?:[-*]\s*)?(?:(?:I|We)\s+)?(?:implemented|changed|edited|updated|modified|created|added|removed|fixed)\b[^\n]*\.(?:tsx|jsx|vue|svelte|css|scss|sass|less)(?=\W|$)/imu.test(message);
 }
 
 function missingReuseReceiptField(source) {
@@ -433,7 +445,8 @@ function hasPassingStructuralEvidence(source) {
 
 function validateUiReuseEvidence(input, workflowRoot, activePlan, planState) {
   const message = input.last_assistant_message || "";
-  if (hasUiChangedFile(message)) {
+  const reportsUiChanges = hasUiChangedFile(message);
+  if (reportsUiChanges) {
     if (!/^UI Reuse Evidence:\s*$/im.test(message)) {
       return "UI files are reported as changed, but final output lacks `UI Reuse Evidence:`. Provide Target, Shared primitive, Layout precedent, Decision, and Structural verification with PASS evidence.";
     }
@@ -444,7 +457,9 @@ function validateUiReuseEvidence(input, workflowRoot, activePlan, planState) {
     }
   }
 
-  if (!activePlan) return null;
+  // An incomplete active UI contract belongs to the plan, not to every chat
+  // turn. Only enforce it when this response actually reports UI changes.
+  if (!activePlan || !reportsUiChanges) return null;
   const contract = readText(path.join(workflowRoot, activePlan, "ui-contract.md"));
   if (!contract || /No UI contract applies unless frontend or visible UI work is in scope\./i.test(contract)) return null;
 
@@ -467,7 +482,7 @@ function subagentStart(input) {
     "No scope creep, lint suppression, or unsupported assumptions.",
     "Context hard gate: the assigned scope or question is a read boundary. Do not inventory or re-read the project after a plan or compaction; if an outside file is essential, name the exact dependency and report `NEEDS_CONTEXT`.",
     "Minimum-solution gate: implement assigned behavior completely; do not add hypothetical hardening or omit acceptance, normal flow, integrity/security, or compatibility to reduce scope.",
-    "UI reuse gate: before coding, require a receipt naming target, shared primitive path/export, analogous layout path, decision, and structural verification. A named reuse instruction is architecture acceptance.",
+    "UI reuse gate: before coding, require a receipt with the exact fields `Target:`, `Shared primitive:`, `Layout precedent:`, `Decision:`, and `Structural verification:`. A named reuse instruction is architecture acceptance.",
     "UI composition gate: shared-components-only means no local substitute or wrapper; use the named primitive and analogous layout or report `NEEDS_CONTEXT`. Behavior tests/screenshots alone do not prove reuse.",
   ];
 

--- a/plugins/workflow/kimi.plugin.json
+++ b/plugins/workflow/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Lean, risk-budgeted workflows for Kimi Code with one primary path, focused context, selective subagents, single-pass verification, and explicit completion gates.",
   "keywords": [
     "kimi",

--- a/plugins/workflow/skills/executing-plans/SKILL.md
+++ b/plugins/workflow/skills/executing-plans/SKILL.md
@@ -25,7 +25,7 @@ Read [references/execution-state.md](references/execution-state.md) only when up
 - Do not write workflow state after every tool call or tiny edit.
 - Execute tasks within their allowed scope and record any approved scope change before editing outside it.
 - Do not perform opportunistic refactors. A new API/schema/protocol/shared abstraction/layer or a higher change class requires an approved plan update and a renewed commitment reflection before implementation continues.
-- For production UI, read the UI contract's reuse receipt before markup/styles. It names target, shared path/export, analogous layout, decision, and structural check. Treat named reuse as architecture acceptance; stop before a local substitute, duplicate primitive, or unapproved layout deviation.
+- For production UI, read the UI contract's reuse receipt before markup/styles. Its exact labels are `Target:`, `Shared primitive:`, `Layout precedent:`, `Decision:`, `Structural verification:`. Treat named reuse as architecture acceptance; stop before a local substitute, duplicate primitive, or unapproved layout deviation.
 - For a small user correction, inspect and edit only the touched surface plus directly affected tests; do not restart repository discovery.
 - For chunks, root owns dependency order and integration. Never create nested chunks.
 

--- a/plugins/workflow/skills/using-workflow/SKILL.md
+++ b/plugins/workflow/skills/using-workflow/SKILL.md
@@ -24,7 +24,7 @@ Read the request and cheap repository facts; run a local `intent-gate` for non-t
 
 ## Context Discipline
 
-Plans/compaction never reset discovery. Use named surfaces; no inventory, hypotheticals, future-proofing, or unrelated refactors. Expand only for required behavior, observed failure, or normal-path risk. UI requires a pre-edit receipt: target, shared path/export, analogous layout, decision, and structural check. A named reuse instruction is an architecture acceptance criterion; visual equivalence fails. custom primitives need explicit user approval and evidence no candidate fits. At cap, proceed only if uncertainty cannot change acceptance; otherwise ask/`NEEDS_CONTEXT`.
+Plans/compaction never reset discovery. Use named surfaces; no inventory, hypotheticals, future-proofing, or unrelated refactors. Expand only for required behavior, observed failure, or normal-path risk. UI requires exact receipt labels: `Target:`, `Shared primitive:`, `Layout precedent:`, `Decision:`, `Structural verification:`. A named reuse instruction is an architecture acceptance criterion; visual equivalence fails. custom primitives need explicit user approval and evidence no candidate fits. At cap, proceed only if uncertainty cannot change acceptance; otherwise ask/`NEEDS_CONTEXT`.
 
 ## Action Boundary
 

--- a/scripts/publish-changed-packages.mjs
+++ b/scripts/publish-changed-packages.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const dryRun = process.argv.includes('--dry-run');
+
+function readPackage(directory) {
+  const manifestPath = path.join(directory, 'package.json');
+  if (!existsSync(manifestPath)) return null;
+
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  if (manifest.private || !manifest.name || !manifest.version) return null;
+
+  return {
+    directory,
+    name: manifest.name,
+    version: manifest.version,
+    access: manifest.publishConfig?.access || 'public',
+  };
+}
+
+function discoverPackages() {
+  const packagesRoot = path.join(repositoryRoot, 'packages');
+  const workspacePackages = readdirSync(packagesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => readPackage(path.join(packagesRoot, entry.name)))
+    .filter(Boolean)
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const rootPackage = readPackage(repositoryRoot);
+  return rootPackage ? [...workspacePackages, rootPackage] : workspacePackages;
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || repositoryRoot,
+    encoding: 'utf8',
+    stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+  });
+
+  if (result.error) throw result.error;
+  return result;
+}
+
+function isPublished({ name, version }) {
+  const result = run('npm', ['view', `${name}@${version}`, 'version', '--json'], { capture: true });
+  if (result.status === 0) return true;
+
+  const output = `${result.stdout || ''}\n${result.stderr || ''}`;
+  if (/\bE404\b|404 Not Found|is not in this registry/i.test(output)) return false;
+
+  throw new Error(`Unable to check ${name}@${version} in npm registry:\n${output.trim()}`);
+}
+
+function publishPackage(packageInfo) {
+  const result = run(
+    'npm',
+    ['publish', '--access', packageInfo.access, '--provenance'],
+    { cwd: packageInfo.directory },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(`npm publish failed for ${packageInfo.name}@${packageInfo.version}`);
+  }
+}
+
+function main() {
+  const packages = discoverPackages();
+
+  if (dryRun) {
+    for (const packageInfo of packages) {
+      console.log(`${packageInfo.name}@${packageInfo.version}`);
+    }
+    return;
+  }
+
+  if (!process.env.NODE_AUTH_TOKEN) {
+    throw new Error('NODE_AUTH_TOKEN is required. Configure the GitHub Actions NPM_TOKEN secret.');
+  }
+
+  for (const packageInfo of packages) {
+    const spec = `${packageInfo.name}@${packageInfo.version}`;
+    if (isPublished(packageInfo)) {
+      console.log(`Skipping ${spec}: already published.`);
+      continue;
+    }
+
+    console.log(`Publishing ${spec}...`);
+    publishPackage(packageInfo);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Fix false-positive Workflow UI reuse checks that were triggered during ordinary conversational responses.

Previously, the Stop hook validated an incomplete active UI contract on every assistant response. It could also treat a simple reference to a frontend source file as a report that UI code had been changed. As a result, unrelated technical questions were blocked with missing UI reuse receipt errors.

## What changed

### Stop hook behavior

- Active UI contracts are no longer validated on every response.
- UI reuse validation now runs only when the response actually reports UI changes.
- A simple reference to a frontend source file is no longer treated as a code change.
- UI changes are detected through:
  - frontend files listed under `Changed files:`;
  - explicit change statements beginning with verbs such as `Implemented`, `Changed`, `Edited`, `Updated`, or `Fixed`.
- Existing enforcement remains in place for genuine UI work:
  - required reuse evidence;
  - complete receipt fields;
  - structural import or wiring verification.

### Receipt field consistency

Standardized the required receipt labels across the runtime hook, workflow skills, and implementer prompts:

- `Target:`
- `Shared primitive:`
- `Layout precedent:`
- `Decision:`
- `Structural verification:`

This removes the previous ambiguity where instructions referred to an “analogous layout path” while the validator accepted only `Layout precedent:`.

### Agent prompt synchronization

Updated the lightweight, standard, and complex implementer prompts for both Codex and Claude-compatible distributions.

### Regression coverage

Added tests covering:

- an ordinary technical answer while an incomplete UI contract is active;
- a conversational reference to a frontend source file without reporting a change;
- a real UI change with a missing receipt;
- incomplete structural verification;
- valid UI reuse evidence;
- exact receipt field labels in runtime and implementer instructions.

## Versioning

Following `CONTRIBUTING.md`, patch versions were updated consistently:

- Workflow runtime: `1.1.8` → `1.1.9`
- Workflow plugin manifests: `1.1.10` → `1.1.11`
- Aggregate Kimi manifest and marketplace version: `1.1.10` → `1.1.11`

## Verification

- Workflow TypeScript typecheck passed.
- Targeted Stop-hook and subagent-hook tests passed.
- Codex, Claude, and Kimi manifest consistency tests passed.
- Skill structure and reference tests passed.
- Runtime and plugin version surfaces were checked for consistency.
- Hook syntax validation passed.
- `git diff --check` passed.

## Scope

This change only affects Workflow hook validation, workflow instructions, implementer prompts, tests, and release versions. It does not modify application UI, wallet, or server behavior.